### PR TITLE
Update copy-with-syntax.js

### DIFF
--- a/lib/copy-with-syntax.js
+++ b/lib/copy-with-syntax.js
@@ -6,7 +6,7 @@ function copyWithSyntax() {
   // contains all lines inside text editor
   var textEditor = atom.workspace.getActiveTextEditor();
   var el = atom.workspace.viewRegistry.getView(textEditor);
-  var lines = findEditorDOM(el.shadowRoot);
+  var lines = findEditorDOM(el);
   if (!lines) {
     throw new Error('Cound not locate lines DOM inside editor');
   }


### PR DESCRIPTION
Fix issue #7

> The contents of atom-text-editor elements are no longer encapsulated
> within a shadow DOM boundary. Please, stop using shadowRoot and access
> the editor contents directly instead.